### PR TITLE
feat: add consolidated accountability test type detection and schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,14 @@ The system determines test type and year from the header:
 - Characters 3-4: School year abbreviation (e.g., 25 for 2025)
 - STAAR EOC files with month 10-14 have their year incremented by 1
 
-**Currently implemented test types:** Only `staar` (month < 10) and `staar_eoc` (month >= 10) are selected by `processor.process_file`. The `crs/` and `staar_alt/` folders under `default_schema/` ship schemas but have no detection branch — adding support requires editing `processor.py:201`.
+**Currently implemented test types:** `processor.process_file` selects:
+
+- `telpas` when "TELPAS" appears in the input filename (case-insensitive)
+- `consolidated_accountability` when "ACCOUNTABILITY" appears in the input filename (case-insensitive); schemas live under `default_schema/consolidated_accountability/`
+- `staar` when the header month is < 10
+- `staar_eoc` otherwise
+
+Filename-based detection runs before month-based detection, so files whose headers would otherwise collide (TELPAS spring months overlap STAAR; accountability files use the year `2025` as their header which parses as month 20) still route correctly. The `crs/` and `staar_alt/` folders under `default_schema/` ship schemas but have no detection branch — adding support requires editing `processor.py:201`.
 
 ## Known Gotchas
 

--- a/src/tea_data_file_conversion/default_schema/consolidated_accountability/consolidated_accountability_2025.yaml
+++ b/src/tea_data_file_conversion/default_schema/consolidated_accountability/consolidated_accountability_2025.yaml
@@ -1,0 +1,4371 @@
+fields:
+  - start: 1
+    end: 4
+    output_field: "Year"
+    keep: false
+    mapped_field_name: .nan
+  - start: 5
+    end: 6
+    output_field: "Region Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 7
+    end: 12
+    output_field: "District Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 13
+    end: 27
+    output_field: "District Name"
+    keep: false
+    mapped_field_name: .nan
+  - start: 28
+    end: 36
+    output_field: "PEIMS ID"
+    keep: false
+    mapped_field_name: .nan
+  - start: 37
+    end: 51
+    output_field: "Last Name"
+    keep: false
+    mapped_field_name: .nan
+  - start: 52
+    end: 61
+    output_field: "First Name"
+    keep: false
+    mapped_field_name: .nan
+  - start: 62
+    end: 62
+    output_field: "Middle Initial"
+    keep: false
+    mapped_field_name: .nan
+  - start: 63
+    end: 70
+    output_field: "Date of Birth"
+    keep: false
+    mapped_field_name: .nan
+  - start: 71
+    end: 90
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 91
+    end: 91
+    output_field: "Sex"
+    keep: false
+    mapped_field_name: .nan
+  - start: 92
+    end: 92
+    output_field: "Hispanic-Latino-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 93
+    end: 93
+    output_field: "American-Indian-Alaska-Native-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 94
+    end: 94
+    output_field: "Asian-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 95
+    end: 95
+    output_field: "Black-African-American-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 96
+    end: 96
+    output_field: "Native-Hawaiian-Pacific-Islander-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 97
+    end: 97
+    output_field: "White-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 98
+    end: 98
+    output_field: "Ethnicity/Race Reporting Category"
+    keep: false
+    mapped_field_name: .nan
+  - start: 99
+    end: 99
+    output_field: "Special-Education-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 100
+    end: 100
+    output_field: "Economic-Disadvantage-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 101
+    end: 101
+    output_field: "Title-I-Part-A-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 102
+    end: 102
+    output_field: "Migrant-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 103
+    end: 103
+    output_field: "Emergent-Bilingual-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 104
+    end: 104
+    output_field: "Bilingual-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 105
+    end: 105
+    output_field: "ESL-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 106
+    end: 106
+    output_field: "Gifted-Talented-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 107
+    end: 107
+    output_field: "At-Risk-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 108
+    end: 108
+    output_field: "New to Texas"
+    keep: false
+    mapped_field_name: .nan
+  - start: 109
+    end: 117
+    output_field: "Local-Student-ID"
+    keep: false
+    mapped_field_name: .nan
+  - start: 118
+    end: 118
+    output_field: "Section-504-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 119
+    end: 119
+    output_field: "ADA Eligibility"
+    keep: false
+    mapped_field_name: .nan
+  - start: 120
+    end: 121
+    output_field: "Alternate-Language-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 122
+    end: 137
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 138
+    end: 138
+    output_field: "Sex"
+    keep: false
+    mapped_field_name: .nan
+  - start: 139
+    end: 139
+    output_field: "Hispanic-Latino-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 140
+    end: 140
+    output_field: "American-Indian-Alaska-Native-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 141
+    end: 141
+    output_field: "Asian-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 142
+    end: 142
+    output_field: "Black-African-American-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 143
+    end: 143
+    output_field: "Native-Hawaiian-Pacific-Islander-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 144
+    end: 144
+    output_field: "White-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 145
+    end: 145
+    output_field: "Ethnicity/Race Reporting Category"
+    keep: false
+    mapped_field_name: .nan
+  - start: 146
+    end: 146
+    output_field: "Special-Education-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 147
+    end: 147
+    output_field: "Economic-Disadvantage-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 148
+    end: 148
+    output_field: "Title-I-Part-A-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 149
+    end: 149
+    output_field: "Migrant-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 150
+    end: 150
+    output_field: "Emergent-Bilingual-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 151
+    end: 151
+    output_field: "Bilingual-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 152
+    end: 152
+    output_field: "ESL-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 153
+    end: 153
+    output_field: "Gifted-Talented-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 154
+    end: 154
+    output_field: "At-Risk-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 155
+    end: 155
+    output_field: "ADA Eligibility"
+    keep: false
+    mapped_field_name: .nan
+  - start: 156
+    end: 156
+    output_field: "Military-Connected-Student-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 157
+    end: 158
+    output_field: "Alternative Language Programs"
+    keep: false
+    mapped_field_name: .nan
+  - start: 159
+    end: 159
+    output_field: "Section-504-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 160
+    end: 178
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 179
+    end: 180
+    output_field: "2024 TSDS PEIMS Snapshot Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 181
+    end: 189
+    output_field: "2024 TSDS PEIMS Snapshot CDC"
+    keep: false
+    mapped_field_name: .nan
+  - start: 190
+    end: 198
+    output_field: "2023 TSDS PEIMS Snapshot CDC"
+    keep: false
+    mapped_field_name: .nan
+  - start: 199
+    end: 200
+    output_field: "2024 TSDS PEIMS Snapshot Crisis-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 201
+    end: 202
+    output_field: "2024 TSDS PEIMS Snapshot Attribution-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 203
+    end: 203
+    output_field: "2024 TSDS PEIMS Snapshot Parental Denial"
+    keep: false
+    mapped_field_name: .nan
+  - start: 204
+    end: 204
+    output_field: "2024 TSDS PEIMS Snapshot Homeless-Status-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 205
+    end: 205
+    output_field: "2024 TSDS PEIMS Snapshot Unaccompanied-Youth-Status-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 206
+    end: 206
+    output_field: "2024 TSDS PEIMS Snapshot Foster-Care-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 207
+    end: 207
+    output_field: "2024 TSDS PEIMS Snapshot Dyslexia-Indicator-Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 208
+    end: 217
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 218
+    end: 223
+    output_field: "Family Portal Unique Access Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 224
+    end: 233
+    output_field: "TX-Unique-Student-ID"
+    keep: false
+    mapped_field_name: .nan
+  - start: 234
+    end: 234
+    output_field: "TAKS/TAAS/TEAMS Tester Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 235
+    end: 244
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 245
+    end: 248
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 249
+    end: 249
+    output_field: "Record Update Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 250
+    end: 259
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 260
+    end: 268
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 269
+    end: 270
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 271
+    end: 271
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 272
+    end: 272
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 273
+    end: 273
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 274
+    end: 274
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 275
+    end: 278
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 279
+    end: 279
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 280
+    end: 280
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 281
+    end: 281
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 282
+    end: 283
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 284
+    end: 284
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 285
+    end: 285
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 286
+    end: 287
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 288
+    end: 288
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 289
+    end: 289
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 290
+    end: 294
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 295
+    end: 303
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 304
+    end: 305
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 306
+    end: 306
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 307
+    end: 307
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 308
+    end: 308
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 309
+    end: 309
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 310
+    end: 313
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 314
+    end: 314
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 315
+    end: 315
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 316
+    end: 316
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 317
+    end: 317
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 318
+    end: 318
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 319
+    end: 319
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 320
+    end: 321
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 322
+    end: 324
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 325
+    end: 333
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 334
+    end: 335
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 336
+    end: 336
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 337
+    end: 337
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 338
+    end: 338
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 339
+    end: 339
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 340
+    end: 343
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 344
+    end: 344
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 345
+    end: 345
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 346
+    end: 346
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 347
+    end: 348
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 349
+    end: 349
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 350
+    end: 351
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 352
+    end: 352
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 353
+    end: 353
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 354
+    end: 354
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 355
+    end: 358
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 359
+    end: 367
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 368
+    end: 369
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 370
+    end: 370
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 371
+    end: 371
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 372
+    end: 372
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 373
+    end: 373
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 374
+    end: 377
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 378
+    end: 378
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 379
+    end: 379
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 380
+    end: 380
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 381
+    end: 382
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 383
+    end: 383
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 384
+    end: 384
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 385
+    end: 386
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 387
+    end: 387
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 388
+    end: 388
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 389
+    end: 393
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 394
+    end: 402
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 403
+    end: 404
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 405
+    end: 405
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 406
+    end: 406
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 407
+    end: 407
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 408
+    end: 408
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 409
+    end: 412
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 413
+    end: 413
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 414
+    end: 414
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 415
+    end: 415
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 416
+    end: 416
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 417
+    end: 417
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 418
+    end: 418
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 419
+    end: 420
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 421
+    end: 423
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 424
+    end: 427
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 428
+    end: 428
+    output_field: "Record Update Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 429
+    end: 438
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 439
+    end: 447
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 448
+    end: 449
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 450
+    end: 450
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 451
+    end: 451
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 452
+    end: 452
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 453
+    end: 453
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 454
+    end: 457
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 458
+    end: 458
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 459
+    end: 459
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 460
+    end: 460
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 461
+    end: 462
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 463
+    end: 463
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 464
+    end: 464
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 465
+    end: 466
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 467
+    end: 467
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 468
+    end: 468
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 469
+    end: 473
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 474
+    end: 482
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 483
+    end: 484
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 485
+    end: 485
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 486
+    end: 486
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 487
+    end: 487
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 488
+    end: 488
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 489
+    end: 492
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 493
+    end: 493
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 494
+    end: 494
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 495
+    end: 495
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 496
+    end: 496
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 497
+    end: 497
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 498
+    end: 498
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 499
+    end: 500
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 501
+    end: 503
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 504
+    end: 512
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 513
+    end: 514
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 515
+    end: 515
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 516
+    end: 516
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 517
+    end: 517
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 518
+    end: 518
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 519
+    end: 522
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 523
+    end: 523
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 524
+    end: 524
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 525
+    end: 525
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 526
+    end: 527
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 528
+    end: 528
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 529
+    end: 530
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 531
+    end: 531
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 532
+    end: 532
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 533
+    end: 533
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 534
+    end: 537
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 538
+    end: 546
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 547
+    end: 548
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 549
+    end: 549
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 550
+    end: 550
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 551
+    end: 551
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 552
+    end: 552
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 553
+    end: 556
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 557
+    end: 557
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 558
+    end: 558
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 559
+    end: 559
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 560
+    end: 561
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 562
+    end: 562
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 563
+    end: 563
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 564
+    end: 565
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 566
+    end: 566
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 567
+    end: 567
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 568
+    end: 572
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 573
+    end: 581
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 582
+    end: 583
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 584
+    end: 584
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 585
+    end: 585
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 586
+    end: 586
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 587
+    end: 587
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 588
+    end: 591
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 592
+    end: 592
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 593
+    end: 593
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 594
+    end: 594
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 595
+    end: 595
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 596
+    end: 596
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 597
+    end: 597
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 598
+    end: 599
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 600
+    end: 602
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 603
+    end: 606
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 607
+    end: 607
+    output_field: "Record Update Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 608
+    end: 617
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 618
+    end: 626
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 627
+    end: 628
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 629
+    end: 629
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 630
+    end: 630
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 631
+    end: 631
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 632
+    end: 632
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 633
+    end: 636
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 637
+    end: 637
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 638
+    end: 638
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 639
+    end: 639
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 640
+    end: 641
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 642
+    end: 642
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 643
+    end: 643
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 644
+    end: 645
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 646
+    end: 646
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 647
+    end: 647
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 648
+    end: 652
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 653
+    end: 661
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 662
+    end: 663
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 664
+    end: 664
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 665
+    end: 665
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 666
+    end: 666
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 667
+    end: 667
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 668
+    end: 671
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 672
+    end: 672
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 673
+    end: 673
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 674
+    end: 674
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 675
+    end: 675
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 676
+    end: 676
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 677
+    end: 677
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 678
+    end: 679
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 680
+    end: 682
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 683
+    end: 691
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 692
+    end: 693
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 694
+    end: 694
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 695
+    end: 695
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 696
+    end: 696
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 697
+    end: 697
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 698
+    end: 701
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 702
+    end: 702
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 703
+    end: 703
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 704
+    end: 704
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 705
+    end: 706
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 707
+    end: 707
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 708
+    end: 709
+    output_field: "Test Form Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 710
+    end: 711
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 712
+    end: 712
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 713
+    end: 713
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 714
+    end: 714
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 715
+    end: 718
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 719
+    end: 727
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 728
+    end: 729
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 730
+    end: 730
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 731
+    end: 731
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 732
+    end: 732
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 733
+    end: 733
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 734
+    end: 737
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 738
+    end: 738
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 739
+    end: 739
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 740
+    end: 740
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 741
+    end: 742
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 743
+    end: 743
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 744
+    end: 744
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 745
+    end: 745
+    output_field: "Previous Year English I First-time/Retester"
+    keep: false
+    mapped_field_name: .nan
+  - start: 746
+    end: 747
+    output_field: "Test Form Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 748
+    end: 749
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 750
+    end: 750
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 751
+    end: 751
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 752
+    end: 756
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 757
+    end: 765
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 766
+    end: 767
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 768
+    end: 768
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 769
+    end: 769
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 770
+    end: 770
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 771
+    end: 771
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 772
+    end: 775
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 776
+    end: 776
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 777
+    end: 777
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 778
+    end: 778
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 779
+    end: 779
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 780
+    end: 780
+    output_field: "High School Equivalency Program (HSEP)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 781
+    end: 781
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 782
+    end: 783
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 784
+    end: 786
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 787
+    end: 790
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 791
+    end: 800
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 801
+    end: 809
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 810
+    end: 811
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 812
+    end: 812
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 813
+    end: 813
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 814
+    end: 814
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 815
+    end: 818
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 819
+    end: 819
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 820
+    end: 820
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 821
+    end: 821
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 822
+    end: 823
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 824
+    end: 825
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 826
+    end: 826
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 827
+    end: 828
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 829
+    end: 837
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 838
+    end: 839
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 840
+    end: 840
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 841
+    end: 841
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 842
+    end: 842
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 843
+    end: 846
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 847
+    end: 847
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 848
+    end: 848
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 849
+    end: 849
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 850
+    end: 851
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 852
+    end: 854
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 855
+    end: 863
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 864
+    end: 865
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 866
+    end: 866
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 867
+    end: 867
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 868
+    end: 868
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 869
+    end: 872
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 873
+    end: 873
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 874
+    end: 874
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 875
+    end: 875
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 876
+    end: 877
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 878
+    end: 879
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 880
+    end: 880
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 881
+    end: 882
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 883
+    end: 891
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 892
+    end: 893
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 894
+    end: 894
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 895
+    end: 895
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 896
+    end: 896
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 897
+    end: 900
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 901
+    end: 901
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 902
+    end: 902
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 903
+    end: 903
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 904
+    end: 905
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 906
+    end: 907
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 908
+    end: 908
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 909
+    end: 910
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 911
+    end: 919
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 920
+    end: 921
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 922
+    end: 922
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 923
+    end: 923
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 924
+    end: 924
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 925
+    end: 928
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 929
+    end: 929
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 930
+    end: 930
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 931
+    end: 931
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 932
+    end: 933
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 934
+    end: 936
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 937
+    end: 940
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 941
+    end: 950
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 951
+    end: 959
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 960
+    end: 961
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 962
+    end: 962
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 963
+    end: 963
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 964
+    end: 964
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 965
+    end: 968
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 969
+    end: 969
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 970
+    end: 970
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 971
+    end: 971
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 972
+    end: 973
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 974
+    end: 975
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 976
+    end: 976
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 977
+    end: 978
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 979
+    end: 987
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 988
+    end: 989
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 990
+    end: 990
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 991
+    end: 991
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 992
+    end: 992
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 993
+    end: 996
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 997
+    end: 997
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 998
+    end: 998
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 999
+    end: 999
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1000
+    end: 1001
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1002
+    end: 1004
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1005
+    end: 1013
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1014
+    end: 1015
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1016
+    end: 1016
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1017
+    end: 1017
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1018
+    end: 1018
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1019
+    end: 1022
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1023
+    end: 1023
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1024
+    end: 1024
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1025
+    end: 1025
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1026
+    end: 1027
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1028
+    end: 1029
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1030
+    end: 1030
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1031
+    end: 1032
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1033
+    end: 1041
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1042
+    end: 1043
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1044
+    end: 1044
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1045
+    end: 1045
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1046
+    end: 1046
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1047
+    end: 1050
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1051
+    end: 1051
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1052
+    end: 1052
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1053
+    end: 1053
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1054
+    end: 1055
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1056
+    end: 1057
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1058
+    end: 1058
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1059
+    end: 1060
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1061
+    end: 1069
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1070
+    end: 1071
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1072
+    end: 1072
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1073
+    end: 1073
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1074
+    end: 1074
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1075
+    end: 1078
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1079
+    end: 1079
+    output_field: "Approaches Grade Level at Student's Standard"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1080
+    end: 1080
+    output_field: "Meets Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1081
+    end: 1081
+    output_field: "Masters Grade Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1082
+    end: 1083
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1084
+    end: 1086
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1087
+    end: 1090
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1091
+    end: 1100
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1101
+    end: 1109
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1110
+    end: 1111
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1112
+    end: 1112
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1113
+    end: 1113
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1114
+    end: 1114
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1115
+    end: 1118
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1119
+    end: 1119
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1120
+    end: 1120
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1121
+    end: 1121
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1122
+    end: 1123
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1124
+    end: 1125
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1126
+    end: 1126
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1127
+    end: 1128
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1129
+    end: 1137
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1138
+    end: 1139
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1140
+    end: 1140
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1141
+    end: 1141
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1142
+    end: 1142
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1143
+    end: 1146
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1147
+    end: 1147
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1148
+    end: 1148
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1149
+    end: 1149
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1150
+    end: 1151
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1152
+    end: 1154
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1155
+    end: 1163
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1164
+    end: 1165
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1166
+    end: 1166
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1167
+    end: 1167
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1168
+    end: 1168
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1169
+    end: 1172
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1173
+    end: 1173
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1174
+    end: 1174
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1175
+    end: 1175
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1176
+    end: 1177
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1178
+    end: 1179
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1180
+    end: 1180
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1181
+    end: 1182
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1183
+    end: 1191
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1192
+    end: 1193
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1194
+    end: 1194
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1195
+    end: 1195
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1196
+    end: 1196
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1197
+    end: 1200
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1201
+    end: 1201
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1202
+    end: 1202
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1203
+    end: 1203
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1204
+    end: 1205
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1206
+    end: 1207
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1208
+    end: 1208
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1209
+    end: 1210
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1211
+    end: 1219
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1220
+    end: 1221
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1222
+    end: 1222
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1223
+    end: 1223
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1224
+    end: 1224
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1225
+    end: 1228
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1229
+    end: 1229
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1230
+    end: 1230
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1231
+    end: 1231
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1232
+    end: 1233
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1234
+    end: 1236
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1237
+    end: 1237
+    output_field: "Student's Performance Standard for Level II"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1238
+    end: 1242
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1243
+    end: 1246
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1247
+    end: 1247
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1248
+    end: 1248
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1249
+    end: 1249
+    output_field: "Alternate Assessment Category"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1250
+    end: 1250
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1251
+    end: 1255
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1256
+    end: 1259
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1260
+    end: 1260
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1261
+    end: 1265
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1266
+    end: 1269
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1270
+    end: 1278
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1279
+    end: 1283
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1284
+    end: 1287
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1288
+    end: 1296
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1297
+    end: 1297
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1298
+    end: 1298
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1299
+    end: 1299
+    output_field: "Alternate Assessment Category"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1300
+    end: 1300
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1301
+    end: 1301
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1302
+    end: 1302
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1303
+    end: 1306
+    output_field: "Scale Score/Alternate Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1307
+    end: 1307
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1308
+    end: 1312
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1313
+    end: 1316
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1317
+    end: 1317
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1318
+    end: 1318
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1319
+    end: 1319
+    output_field: "Alternate Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1320
+    end: 1320
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1321
+    end: 1325
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1326
+    end: 1329
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1330
+    end: 1330
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1331
+    end: 1335
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1336
+    end: 1339
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1340
+    end: 1348
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1349
+    end: 1353
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1354
+    end: 1357
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1358
+    end: 1366
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1367
+    end: 1367
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1368
+    end: 1368
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1369
+    end: 1369
+    output_field: "Alternate Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1370
+    end: 1370
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1371
+    end: 1371
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1372
+    end: 1372
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1373
+    end: 1376
+    output_field: "Scale Score/Alternate Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1377
+    end: 1377
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1378
+    end: 1382
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1383
+    end: 1386
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1387
+    end: 1387
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1388
+    end: 1388
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1389
+    end: 1389
+    output_field: "Alternate Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1390
+    end: 1390
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1391
+    end: 1395
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1396
+    end: 1399
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1400
+    end: 1400
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1401
+    end: 1405
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1406
+    end: 1409
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1410
+    end: 1418
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1419
+    end: 1423
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1424
+    end: 1427
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1428
+    end: 1436
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1437
+    end: 1437
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1438
+    end: 1438
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1439
+    end: 1439
+    output_field: "Alternate Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1440
+    end: 1440
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1441
+    end: 1441
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1442
+    end: 1442
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1443
+    end: 1446
+    output_field: "Scale Score/Alternate Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1447
+    end: 1447
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1448
+    end: 1452
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1453
+    end: 1456
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1457
+    end: 1457
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1458
+    end: 1458
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1459
+    end: 1459
+    output_field: "Alternate Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1460
+    end: 1460
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1461
+    end: 1465
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1466
+    end: 1469
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1470
+    end: 1470
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1471
+    end: 1475
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1476
+    end: 1479
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1480
+    end: 1488
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1489
+    end: 1493
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1494
+    end: 1497
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1498
+    end: 1506
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1507
+    end: 1507
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1508
+    end: 1508
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1509
+    end: 1509
+    output_field: "Alternate Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1510
+    end: 1510
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1511
+    end: 1511
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1512
+    end: 1512
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1513
+    end: 1516
+    output_field: "Scale Score/Alternate Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1517
+    end: 1517
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1518
+    end: 1522
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1523
+    end: 1526
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1527
+    end: 1527
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1528
+    end: 1528
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1529
+    end: 1529
+    output_field: "Alternate Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1530
+    end: 1530
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1531
+    end: 1535
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1536
+    end: 1539
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1540
+    end: 1540
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1541
+    end: 1545
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1546
+    end: 1549
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1550
+    end: 1558
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1559
+    end: 1563
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1564
+    end: 1567
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1568
+    end: 1576
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1577
+    end: 1577
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1578
+    end: 1578
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1579
+    end: 1579
+    output_field: "Alternate Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1580
+    end: 1580
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1581
+    end: 1581
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1582
+    end: 1582
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1583
+    end: 1586
+    output_field: "Scale Score/Alternate Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1587
+    end: 1587
+    output_field: "Substitute Assessment"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1588
+    end: 1592
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1593
+    end: 1596
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1597
+    end: 1597
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1598
+    end: 1598
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1599
+    end: 1603
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1604
+    end: 1607
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1608
+    end: 1608
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1609
+    end: 1613
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1614
+    end: 1617
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1618
+    end: 1618
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1619
+    end: 1619
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1620
+    end: 1624
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1625
+    end: 1628
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1629
+    end: 1629
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1630
+    end: 1634
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1635
+    end: 1638
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1639
+    end: 1639
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1640
+    end: 1640
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1641
+    end: 1645
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1646
+    end: 1649
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1650
+    end: 1650
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1651
+    end: 1655
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1656
+    end: 1659
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1660
+    end: 1660
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1661
+    end: 1661
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1662
+    end: 1666
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1667
+    end: 1670
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1671
+    end: 1671
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1672
+    end: 1676
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1677
+    end: 1680
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1681
+    end: 1681
+    output_field: "Record Update Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1682
+    end: 1691
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1692
+    end: 1700
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1701
+    end: 1702
+    output_field: "Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1703
+    end: 1703
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1704
+    end: 1704
+    output_field: "Language"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1705
+    end: 1705
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1706
+    end: 1706
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1707
+    end: 1707
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1708
+    end: 1711
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1712
+    end: 1712
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1713
+    end: 1713
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1714
+    end: 1714
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1715
+    end: 1716
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1717
+    end: 1717
+    output_field: "Above Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1718
+    end: 1719
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1720
+    end: 1720
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1721
+    end: 1721
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1722
+    end: 1722
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1723
+    end: 1724
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1725
+    end: 1734
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1735
+    end: 1743
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1744
+    end: 1745
+    output_field: "Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1746
+    end: 1746
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1747
+    end: 1747
+    output_field: "Language"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1748
+    end: 1748
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1749
+    end: 1749
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1750
+    end: 1750
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1751
+    end: 1754
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1755
+    end: 1755
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1756
+    end: 1756
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1757
+    end: 1757
+    output_field: "Masters Grade Level/Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1758
+    end: 1759
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1760
+    end: 1760
+    output_field: "Above Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1761
+    end: 1762
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1763
+    end: 1763
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1764
+    end: 1764
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1765
+    end: 1765
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1766
+    end: 1767
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1768
+    end: 1768
+    output_field: "Mathematics Badge Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1769
+    end: 1778
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1779
+    end: 1787
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1788
+    end: 1789
+    output_field: "Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1790
+    end: 1790
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1791
+    end: 1791
+    output_field: "Language"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1792
+    end: 1792
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1793
+    end: 1793
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1794
+    end: 1794
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1795
+    end: 1798
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1799
+    end: 1799
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1800
+    end: 1800
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1801
+    end: 1801
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1802
+    end: 1803
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1804
+    end: 1804
+    output_field: "Above Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1805
+    end: 1805
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1806
+    end: 1806
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1807
+    end: 1808
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1809
+    end: 1816
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1817
+    end: 1825
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1826
+    end: 1827
+    output_field: "Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1828
+    end: 1828
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1829
+    end: 1829
+    output_field: "Language"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1830
+    end: 1830
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1831
+    end: 1831
+    output_field: "Score Code Default"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1832
+    end: 1832
+    output_field: "Test Administration Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1833
+    end: 1836
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1837
+    end: 1837
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1838
+    end: 1838
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1839
+    end: 1839
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1840
+    end: 1841
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1842
+    end: 1842
+    output_field: "Above Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1843
+    end: 1843
+    output_field: "EL Performance Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1844
+    end: 1844
+    output_field: "Accommodation(s) Used"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1845
+    end: 1846
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1847
+    end: 1854
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1855
+    end: 1858
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1859
+    end: 1868
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1869
+    end: 1877
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1878
+    end: 1879
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1880
+    end: 1881
+    output_field: "Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1882
+    end: 1882
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1883
+    end: 1883
+    output_field: "Language"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1884
+    end: 1884
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1885
+    end: 1888
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1889
+    end: 1889
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1890
+    end: 1890
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1891
+    end: 1891
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1892
+    end: 1893
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1894
+    end: 1895
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1896
+    end: 1896
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1897
+    end: 1898
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1899
+    end: 1907
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1908
+    end: 1909
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1910
+    end: 1911
+    output_field: "Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1912
+    end: 1912
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1913
+    end: 1913
+    output_field: "Language"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1914
+    end: 1914
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1915
+    end: 1918
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1919
+    end: 1919
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1920
+    end: 1920
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1921
+    end: 1921
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1922
+    end: 1923
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1924
+    end: 1925
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1926
+    end: 1926
+    output_field: "STAAR Progress Measure"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1927
+    end: 1928
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1929
+    end: 1929
+    output_field: "Algebra I Summer 2022 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1930
+    end: 1930
+    output_field: "Algebra I Fall 2022 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1931
+    end: 1931
+    output_field: "Algebra I Spring 2023 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1932
+    end: 1932
+    output_field: "English I Summer 2022 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1933
+    end: 1933
+    output_field: "English I Fall 2022 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1934
+    end: 1934
+    output_field: "English I Spring 2023 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1935
+    end: 1935
+    output_field: "English II Summer 2022 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1936
+    end: 1936
+    output_field: "English II Fall 2022 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1937
+    end: 1937
+    output_field: "English II Spring 2023 Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1938
+    end: 1938
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1939
+    end: 1942
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1943
+    end: 1951
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1952
+    end: 1953
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1954
+    end: 1955
+    output_field: "Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1956
+    end: 1956
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1957
+    end: 1957
+    output_field: "Language"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1958
+    end: 1958
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1959
+    end: 1962
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1963
+    end: 1963
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1964
+    end: 1964
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1965
+    end: 1965
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1966
+    end: 1967
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1968
+    end: 1969
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1970
+    end: 1970
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1971
+    end: 1979
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1980
+    end: 1981
+    output_field: "Enrolled Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1982
+    end: 1983
+    output_field: "Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1984
+    end: 1984
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1985
+    end: 1985
+    output_field: "Language"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1986
+    end: 1986
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1987
+    end: 1990
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1991
+    end: 1991
+    output_field: "Approaches Grade Level at Student's Standard/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1992
+    end: 1992
+    output_field: "Meets Grade Level/Level II: Satisfactory Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1993
+    end: 1993
+    output_field: "Masters Grade Level/Level III: Accomplished Academic Performance"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1994
+    end: 1995
+    output_field: "Performance Level Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1996
+    end: 1997
+    output_field: "Raw Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1998
+    end: 1998
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 1999
+    end: 2002
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2003
+    end: 2003
+    output_field: "Record Update Indicator"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2004
+    end: 2004
+    output_field: "Unschooled Asylee/Refugee"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2005
+    end: 2005
+    output_field: "Students with Interrupted Formal Education (SIFE)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2006
+    end: 2006
+    output_field: "Years in U.S. Schools"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2007
+    end: 2007
+    output_field: "Parental Denial"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2008
+    end: 2008
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2009
+    end: 2018
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2019
+    end: 2019
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2020
+    end: 2020
+    output_field: "Proficiency Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2021
+    end: 2022
+    output_field: "Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2023
+    end: 2026
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2027
+    end: 2028
+    output_field: "Reading Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2029
+    end: 2036
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2037
+    end: 2037
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2038
+    end: 2038
+    output_field: "Proficiency Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2039
+    end: 2040
+    output_field: "Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2041
+    end: 2044
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2045
+    end: 2046
+    output_field: "Writing Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2047
+    end: 2054
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2055
+    end: 2055
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2056
+    end: 2056
+    output_field: "Proficiency Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2057
+    end: 2058
+    output_field: "Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2059
+    end: 2062
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2063
+    end: 2064
+    output_field: "Listening Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2065
+    end: 2072
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2073
+    end: 2073
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2074
+    end: 2074
+    output_field: "Proficiency Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2075
+    end: 2076
+    output_field: "Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2077
+    end: 2080
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2081
+    end: 2082
+    output_field: "Speaking Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2083
+    end: 2090
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2091
+    end: 2093
+    output_field: "Composite Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2094
+    end: 2094
+    output_field: "Composite Rating"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2095
+    end: 2103
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2104
+    end: 2113
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2114
+    end: 2117
+    output_field: "Administration Date"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2118
+    end: 2118
+    output_field: "Test Version"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2119
+    end: 2128
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2129
+    end: 2129
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2130
+    end: 2130
+    output_field: "Proficiency Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2131
+    end: 2132
+    output_field: "Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2133
+    end: 2136
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2137
+    end: 2138
+    output_field: "Reading Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2139
+    end: 2141
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2142
+    end: 2142
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2143
+    end: 2143
+    output_field: "Proficiency Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2144
+    end: 2145
+    output_field: "Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2146
+    end: 2149
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2150
+    end: 2151
+    output_field: "Writing Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2152
+    end: 2154
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2155
+    end: 2155
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2156
+    end: 2156
+    output_field: "Proficiency Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2157
+    end: 2158
+    output_field: "Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2159
+    end: 2162
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2163
+    end: 2164
+    output_field: "Listening Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2165
+    end: 2167
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2168
+    end: 2168
+    output_field: "Score Code"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2169
+    end: 2169
+    output_field: "Proficiency Level"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2170
+    end: 2171
+    output_field: "Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2172
+    end: 2175
+    output_field: "Scale Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2176
+    end: 2177
+    output_field: "Speaking Tested Grade"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2178
+    end: 2180
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2181
+    end: 2183
+    output_field: "Composite Score"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2184
+    end: 2184
+    output_field: "Composite Rating"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2185
+    end: 2193
+    output_field: "County-District-Campus Number"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2194
+    end: 2194
+    output_field: "EL Performance Measure Plan (non-English I/II)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2195
+    end: 2195
+    output_field: "EL Performance Measure Plan (English I/II)"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2196
+    end: 2199
+    output_field: "Year ELPM Plan Determined"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2200
+    end: 2200
+    output_field: "Plan-Year TELPAS Composite Rating"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2201
+    end: 2205
+    output_field: "Blank"
+    keep: false
+    mapped_field_name: .nan
+  - start: 2206
+    end: 2206
+    output_field: "Period"
+    keep: false
+    mapped_field_name: .nan

--- a/src/tea_data_file_conversion/processor.py
+++ b/src/tea_data_file_conversion/processor.py
@@ -200,8 +200,14 @@ def process_file(input_file, output_file=None, schema_folder=None, filter_column
     # Determine test type and adjust school year if necessary.
     # TELPAS shares STAAR's spring month range, so it cannot be distinguished by
     # header month alone; detect it from the input filename instead.
-    if "TELPAS" in os.path.basename(input_file).upper():
+    # The consolidated accountability data file uses "2025" (year) as its header,
+    # which would otherwise misroute via the month-based fallback (test_month=20
+    # falls into the staar_eoc branch); detect it from the filename instead.
+    basename_upper = os.path.basename(input_file).upper()
+    if "TELPAS" in basename_upper:
         test_name = "telpas"
+    elif "ACCOUNTABILITY" in basename_upper:
+        test_name = "consolidated_accountability"
     elif test_month < 10:
         test_name = "staar"
     else:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,4 +1,5 @@
 import os
+from itertools import pairwise
 
 import pandas as pd
 import pytest
@@ -147,6 +148,61 @@ def test_telpas_default_schema_is_valid():
     config = load_yaml_config(schema_path)
     validate_yaml_config(config, schema_path)  # Should not raise.
     assert max(field["end"] for field in config["fields"]) == 1200
+
+
+def test_process_file_detects_consolidated_accountability_by_filename(tmp_path):
+    """A filename containing ACCOUNTABILITY routes to the consolidated_accountability
+    schema even when the header (2025 = month 20) would otherwise fall into staar_eoc."""
+    # Header "2025" parses to test_month=20, which would otherwise hit the staar_eoc branch.
+    input_data = "2025ABCDEF\nXYZ456789"
+    input_file = tmp_path / "DF_25_101902_Accountability_V01_07212025.txt"
+    input_file.write_text(input_data)
+
+    schema_folder = tmp_path / "schemas"
+    accountability_folder = schema_folder / "consolidated_accountability"
+    accountability_folder.mkdir(parents=True)
+    schema_content = """
+    fields:
+      - start: 1
+        end: 4
+        output_field: "accountability_year"
+        keep: false
+      - start: 5
+        end: 10
+        output_field: "accountability_field"
+        keep: false
+    """
+    (accountability_folder / "consolidated_accountability_2025.yaml").write_text(schema_content)
+
+    output_file = tmp_path / "output.csv"
+    df = process_file(str(input_file), str(output_file), schema_folder=str(schema_folder))
+
+    assert os.path.exists(output_file)
+    # Columns come from the accountability schema, confirming it was selected over staar_eoc.
+    assert list(df.columns) == ["accountability_year", "accountability_field"]
+    assert df.loc[0, "accountability_year"] == "2025"
+
+
+def test_consolidated_accountability_default_schema_is_valid():
+    """The shipped consolidated accountability 2024-2025 schema validates and covers positions 1-2206."""
+    schema_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "src",
+        "tea_data_file_conversion",
+        "default_schema",
+        "consolidated_accountability",
+        "consolidated_accountability_2025.yaml",
+    )
+    config = load_yaml_config(schema_path)
+    validate_yaml_config(config, schema_path)  # Should not raise.
+    fields = sorted(config["fields"], key=lambda f: f["start"])
+    assert fields[0]["start"] == 1
+    assert fields[-1]["end"] == 2206
+    # Every position 1..2206 covered exactly once (no gaps, no overlaps).
+    for prev, curr in pairwise(fields):
+        assert prev["end"] + 1 == curr["start"], (
+            f"Gap or overlap between fields ending at {prev['end']} and starting at {curr['start']}"
+        )
 
 
 def test_process_fixed_width_file_preserves_strings(tmp_path):


### PR DESCRIPTION
## Summary
- Adds filename-based detection for the TEA Consolidated Accountability Data File: routes to `consolidated_accountability` when `ACCOUNTABILITY` appears in the input filename. Mirrors the TELPAS pattern from `ce4c867`, since the accountability header `2025` (year) parses as `test_month=20` and would otherwise misroute to `staar_eoc`.
- Ships a complete `default_schema/consolidated_accountability/consolidated_accountability_2025.yaml` covering all 2206 positions (874 fields, 93 blank/filler), extracted verbatim from the TEA 2024-2025 spec PDF (pages 3-41). All entries default to `keep: false` / `mapped_field_name: .nan` to match the TELPAS style; toggle as needed later.
- Adds two tests mirroring the TELPAS test pair: a filename-routing test and a default-schema validity test (the latter asserts gap-free / overlap-free coverage across positions 1-2206).
- Refreshes the "Currently implemented test types" section of `CLAUDE.md` to reflect both TELPAS and consolidated accountability.

## Test plan
- [x] `uv run pytest` — all 13 tests pass
- [x] `uv run ruff check --line-length=120` clean on modified files
- [x] `uv run ruff format --check --line-length=120` clean on modified files
- [x] End-to-end CLI run on real sample file `DF_25_101902_Accountability_V01_07212025.txt` produces a 45,479-row × 874-column CSV with the expected schema-config log line
- [ ] CI pipeline green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)